### PR TITLE
Fixed Location parsing for states that have spaces in their name.

### DIFF
--- a/lib/people_places_things/location.rb
+++ b/lib/people_places_things/location.rb
@@ -16,7 +16,10 @@ module PeoplePlacesThings
       #
       3.times do |i|
         self.state = State.new(tokens.last(i).join(" ")) rescue nil
-        tokens = tokens.slice(0..(-1 - i)) if self.state
+        if self.state
+          tokens = tokens.slice(0..(-1 - i))
+          break
+        end
       end
       
       # remainder must be city

--- a/lib/people_places_things/location.rb
+++ b/lib/people_places_things/location.rb
@@ -5,18 +5,20 @@ module PeoplePlacesThings
     def initialize(str)
       self.raw = str
     
-      tokens = str.split(/\s|,/).collect {|t| t.strip}
+      tokens = str.split(/\s|,/).collect { |t| t.strip }.reject { |t| t.length == 0 }
     
       # try to parse last token as zip
       #
       self.zip = ZipCode.new(tokens.last) rescue nil
       tokens = tokens.slice(0..-2) if self.zip
-    
-      # try to parse last token as state
+      
+      # try to parse out the state (california, new york, district of columbia)
       #
-      self.state = State.new(tokens.last) rescue nil
-      tokens = tokens.slice(0..-2) if self.state
-    
+      3.times do |i|
+        self.state = State.new(tokens.last(i).join(" ")) rescue nil
+        tokens = tokens.slice(0..(-1 - i)) if self.state
+      end
+      
       # remainder must be city
       #
       self.city = tokens.join(' ').strip

--- a/spec/people_places_things/location_spec.rb
+++ b/spec/people_places_things/location_spec.rb
@@ -17,6 +17,18 @@ describe Location do
     test_location("san francisco, ca", "san francisco", "CA", nil)
   end
   
+  it "should parse city comma full state" do
+    test_location("new york, new york", "new york", "NY", nil)
+  end
+  
+  it "should parse city comma full state zip" do
+    test_location("new york, new york 10016", "new york", "NY", "10016")
+  end
+  
+  it "should parse city full state zip" do
+    test_location("new york new york 10016", "new york", "NY", "10016")
+  end
+  
   it "should parse city state zip" do
     test_location("san francisco ca 94114-1212", "san francisco", "CA", '94114-1212')
   end

--- a/spec/people_places_things/location_spec.rb
+++ b/spec/people_places_things/location_spec.rb
@@ -8,6 +8,10 @@ describe Location do
   it "should parse city state abbreviation" do
     test_location("san francisco ca", "san francisco", "CA", nil)
   end
+  
+  it "should parse city comma state abbr" do
+    test_location("marlboro, nj", "marlboro", "NJ", nil)
+  end
 
   it "should parse city state full" do
     test_location("san francisco california", "san francisco", "CA", nil)


### PR DESCRIPTION
Location parsing now properly handles states like New York, New Jersey, District of Columbia, etc properly.

I was having a problem with parsing locations like "New York, New York" and "Marlboro, New Jersey" and this seems to have straightened it out.

Hope this helps!
